### PR TITLE
Fix deprecated curly braces for array access

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -237,8 +237,8 @@ class block_leaderboard_observer {
             // Create data for table.
             $forumdata = new \stdClass();
             $forumdata->studentid = $event->userid;
-            $forumdata->forumid = $event->other{'moodleoverflowid'};
-            $forumdata->discussionid = $event->other{'discussionid'};
+            $forumdata->forumid = $event->other['moodleoverflowid'];
+            $forumdata->discussionid = $event->other['discussionid'];
             $forumdata->postid = $event->objectid;
             $forumdata->isresponse = true;
             $forumdata->pointsearned = get_config('block_leaderboard', 'forumresponsepoints');


### PR DESCRIPTION
Array and string offset access syntax with curly braces is no longer supported. This caused the following test to Error:
```
1) restore_stepslib_date_testcase::test_question_attempt_steps_date_restore
Array and string offset access syntax with curly braces is deprecated

/var/www/site/blocks/leaderboard/classes/observer.php:240
/var/www/site/lib/classes/component.php:135
/var/www/site/lib/classes/component.php:135
/var/www/site/lib/classes/event/manager.php:153
/var/www/site/lib/classes/event/manager.php:75
/var/www/site/lib/classes/event/base.php:834
/var/www/site/mod/quiz/locallib.php:375
/var/www/site/backup/moodle2/tests/restore_stepslib_date_test.php:364
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/site/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "restore_stepslib_date_testcase" backup/moodle2/tests/restore_stepslib_date_test.php
 ```
 